### PR TITLE
Add touch-based MIDI pads

### DIFF
--- a/src/rbbrto.css.js
+++ b/src/rbbrto.css.js
@@ -136,12 +136,28 @@ export default `
 
 
 rbbrto-settings {
-	position: absolute;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	height: var(--settings-height, 10%);
-	/* opacity:  0.5; */
+        position: absolute;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        height: var(--settings-height, 10%);
+        /* opacity:  0.5; */
+}
+
+.pad {
+        position: absolute;
+        left: 0;
+        width: 100%;
+        height: 50%;
+        touch-action: none;
+        z-index: 10;
+        background: rgba(255, 255, 255, 0.05);
+}
+.pad-top {
+        top: 0;
+}
+.pad-bottom {
+        top: 50%;
 }
 
 `;


### PR DESCRIPTION
## Summary
- replace keyboard controls with two draggable touch pads for triggering MIDI notes
- style pads to split the screen horizontally

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68963bcfcdf0832f92ab56b05edfacb7