### PR TITLE
Replace gorilla and professor with big foot toes

### DIFF
--- a/src/drum.js
+++ b/src/drum.js
@@ -1,66 +1,66 @@
 import * as c from './constants.js';
 
 /**
- * Mappings of the gorilla's states for each key
+ * Mappings of the right foot's toe states for each key
  */
 export default [
-	// 0 F kick:
-	{ face: 5, hands: 'lr', layer: '#ad0' },
-	// 1 F# 'kick-alt':
-	{ face: 0, hands: 'lr', layer: '#ad1' },
-	// 2 G snare:
-	{ face: 1, hands: 'r', layer: '#ad2' },
-	// 3 G# 'snare-alt':
-	{ face: 2, hands: 'l', layer: '#ad3' },
-	// 4 A rimshot:
-	{ face: 3, hands: 'r', layer: '#ad4' },
-	// 5 A# 'hand-clap':
-	{ face: 4, hands: 'l', layer: '#ad5' },
-	// 6 B tambourine:
-	{ face: 5, hands: 'r', layer: '#ad6' },
+        // 0 F kick:
+        { face: 5, toes: 'lr', layer: '#ad0' },
+        // 1 F# 'kick-alt':
+        { face: 0, toes: 'lr', layer: '#ad1' },
+        // 2 G snare:
+        { face: 1, toes: 'r', layer: '#ad2' },
+        // 3 G# 'snare-alt':
+        { face: 2, toes: 'l', layer: '#ad3' },
+        // 4 A rimshot:
+        { face: 3, toes: 'r', layer: '#ad4' },
+        // 5 A# 'toe-clap':
+        { face: 4, toes: 'l', layer: '#ad5' },
+        // 6 B tambourine:
+        { face: 5, toes: 'r', layer: '#ad6' },
 
-	// 7 C '08':
-	{ face: 0, hands: 'l', layer: '#ad7' },
-	// 8 C# 'closed-hihat':
-	{ face: 1, hands: 'r', layer: '#ad8' },
-	// 9 D '09':
-	{ face: 2, hands: 'l', layer: '#ad9' },
-	// 10 D# 'open-hihat':
-	{ face: 3, cowbell: false, hands: 'r', layer: '#ad10_1_' },
-	// 11 E '10':
-	{ face: 4, hands: '', layer: '#ad11' },
-	//
-	////
-	///
-	// 0 F kick:
-	{ face: 5, hands: 'lr', layer: '#ad0' },
-	// 1 F# 'kick-alt':
-	{ face: 0, hands: 'lr', layer: '#ad1' },
-	// 2 G snare:
-	{ face: 1, hands: 'r', layer: '#ad2' },
-	// 3 G# 'snare-alt':
-	{ face: 2, hands: 'l', layer: '#ad3' },
-	// 4 A rimshot:
-	{ face: 3, hands: 'r', layer: '#ad4' },
-	// 5 A# 'hand-clap':
-	{ face: 4, hands: 'l', layer: '#ad5' },
-	// 6 B tambourine:
-	{ face: 5, hands: 'r', layer: '#ad6' },
+        // 7 C '08':
+        { face: 0, toes: 'l', layer: '#ad7' },
+        // 8 C# 'closed-hihat':
+        { face: 1, toes: 'r', layer: '#ad8' },
+        // 9 D '09':
+        { face: 2, toes: 'l', layer: '#ad9' },
+        // 10 D# 'open-hihat':
+        { face: 3, cowbell: false, toes: 'r', layer: '#ad10_1_' },
+        // 11 E '10':
+        { face: 4, toes: '', layer: '#ad11' },
+        //
+        ////
+        ///
+        // 0 F kick:
+        { face: 5, toes: 'lr', layer: '#ad0' },
+        // 1 F# 'kick-alt':
+        { face: 0, toes: 'lr', layer: '#ad1' },
+        // 2 G snare:
+        { face: 1, toes: 'r', layer: '#ad2' },
+        // 3 G# 'snare-alt':
+        { face: 2, toes: 'l', layer: '#ad3' },
+        // 4 A rimshot:
+        { face: 3, toes: 'r', layer: '#ad4' },
+        // 5 A# 'toe-clap':
+        { face: 4, toes: 'l', layer: '#ad5' },
+        // 6 B tambourine:
+        { face: 5, toes: 'r', layer: '#ad6' },
 
-	// 7 C '08':
-	{ face: 0, hands: 'l', layer: '#ad7' },
-	// 8 C# 'closed-hihat':
-	{ face: 1, hands: 'r', layer: '#ad8' },
-	// 9 D '09':
-	{ face: 2, hands: 'l', layer: '#ad9' },
-	// 10 D# 'open-hihat':
-	{ face: 3, cowbell: false, hands: 'r', layer: '#ad10_1_' },
-	// 11 E '10':
-	{ face: 4, hands: '', layer: '#ad11' }
+        // 7 C '08':
+        { face: 0, toes: 'l', layer: '#ad7' },
+        // 8 C# 'closed-hihat':
+        { face: 1, toes: 'r', layer: '#ad8' },
+        // 9 D '09':
+        { face: 2, toes: 'l', layer: '#ad9' },
+        // 10 D# 'open-hihat':
+        { face: 3, cowbell: false, toes: 'r', layer: '#ad10_1_' },
+        // 11 E '10':
+        { face: 4, toes: '', layer: '#ad11' }
 ];
 
-export const DRUM_HAND_LEFT = '#ahand_x5F_left';
-export const DRUM_HAND_RIGHT = '#ahand_x5F_right';
+export const DRUM_TOE_LEFT = '#ahand_x5F_left';
+export const DRUM_TOE_RIGHT = '#ahand_x5F_right';
 export const COWBELL = '#cowbella';
 export const FACE = type => {
 	switch (type) {

--- a/src/rbbrto.css.js
+++ b/src/rbbrto.css.js
@@ -96,12 +96,12 @@ export default `
 	}
 }
 
-/* Synth hand animation */
+/* Synth toe animation */
 #hbld.hit,
 #hbrd.hit {
-	animation-name: hand-hit;
+        animation-name: toe-hit;
 }
-@keyframes hand-hit {
+@keyframes toe-hit {
 	from {
 		transform: translate(var(--translate-x), -2.93px);
 	}

--- a/src/rbbrto.js
+++ b/src/rbbrto.js
@@ -1,18 +1,18 @@
 import { drumPatterns, synthPatterns } from './patterns.js';
 import drum, {
-	DRUM_HAND_LEFT,
-	DRUM_HAND_RIGHT,
-	COWBELL,
-	FACE
+        DRUM_TOE_LEFT,
+        DRUM_TOE_RIGHT,
+        COWBELL,
+        FACE
 } from './drum.js';
 import {
-	SYNTH_LEFT,
-	SYNTH_BITS_LEFT,
-	KEY_GUIDE,
-	SYNTH_IDLE_HAND_LEFT,
-	SYNTH_IDLE_HAND_RIGHT,
-	SYNTH_PLAY_HAND_LEFT,
-	SYNTH_PLAY_HAND_RIGHT
+        SYNTH_LEFT,
+        SYNTH_BITS_LEFT,
+        KEY_GUIDE,
+        SYNTH_IDLE_TOE_LEFT,
+        SYNTH_IDLE_TOE_RIGHT,
+        SYNTH_PLAY_TOE_LEFT,
+        SYNTH_PLAY_TOE_RIGHT
 } from './synth.js';
 import MIDI, { whiteKeys, idxToMidi } from './midi.js';
 import css from './rbbrto.css.js';
@@ -463,34 +463,34 @@ class Rbbrto extends HTMLElement {
 			this[$activeSynthNotes].push(idxToMidi(notesArr[1]));
 		}
 
-		if (notesArr.length === 1) {
-			// Play single notes with the appropriate hand
-			const relNote = idxToMidi(notesArr[0]) % 12;
-			if (relNote < 6) {
-				this._hide(SYNTH_IDLE_HAND_LEFT);
-				this._hitSynthKey(SYNTH_PLAY_HAND_LEFT, relNote);
-			} else {
-				this._hide(SYNTH_IDLE_HAND_RIGHT);
-				this._hitSynthKey(SYNTH_PLAY_HAND_RIGHT, relNote);
-			}
-		} else {
-			// Play multiple notes with two hands
-			this._hide([SYNTH_IDLE_HAND_LEFT, SYNTH_IDLE_HAND_RIGHT]);
-			const relNotesArr = [
-				idxToMidi(notesArr[0]) % 12,
-				idxToMidi(notesArr[1]) % 12
-			];
-			this._hitSynthKey(SYNTH_PLAY_HAND_LEFT, Math.min(...relNotesArr));
-			this._hitSynthKey(SYNTH_PLAY_HAND_RIGHT, Math.max(...relNotesArr));
-		}
+                if (notesArr.length === 1) {
+                        // Play single notes with the appropriate toe
+                        const relNote = idxToMidi(notesArr[0]) % 12;
+                        if (relNote < 6) {
+                                this._hide(SYNTH_IDLE_TOE_LEFT);
+                                this._hitSynthKey(SYNTH_PLAY_TOE_LEFT, relNote);
+                        } else {
+                                this._hide(SYNTH_IDLE_TOE_RIGHT);
+                                this._hitSynthKey(SYNTH_PLAY_TOE_RIGHT, relNote);
+                        }
+                } else {
+                        // Play multiple notes with two toes
+                        this._hide([SYNTH_IDLE_TOE_LEFT, SYNTH_IDLE_TOE_RIGHT]);
+                        const relNotesArr = [
+                                idxToMidi(notesArr[0]) % 12,
+                                idxToMidi(notesArr[1]) % 12
+                        ];
+                        this._hitSynthKey(SYNTH_PLAY_TOE_LEFT, Math.min(...relNotesArr));
+                        this._hitSynthKey(SYNTH_PLAY_TOE_RIGHT, Math.max(...relNotesArr));
+                }
 	}
 
-	/**
-	 * Animate hitting a key with a hand
-	 * @param  {string} hand DOM selector
-	 * @param  {int} relNote Relative note position
-	 */
-	_hitSynthKey(hand, relNote) {
+        /**
+         * Animate hitting a key with a toe
+         * @param  {string} toe DOM selector
+         * @param  {int} relNote Relative note position
+         */
+        _hitSynthKey(toe, relNote) {
 		// Memoize the key positions to improve performance
 		if (!this[$synthKeyX]) {
 			this[$synthKeyX] = [];
@@ -506,17 +506,17 @@ class Rbbrto extends HTMLElement {
 				.getAttribute('x1');
 		}
 
-		this._show(hand);
+                this._show(toe);
 
-		// Calculate the x-offset of the hand and set it in a CSS custom property
-		// (it will be used in the CSS keyframe animation)
-		const xDiff = this[$synthKeyX][relNote] - this[$synthKeyX][0];
-		this.shadow
-			.querySelector(hand)
-			.style.setProperty('--translate-x', `${xDiff}px`);
+                // Calculate the x-offset of the toe and set it in a CSS custom property
+                // (it will be used in the CSS keyframe animation)
+                const xDiff = this[$synthKeyX][relNote] - this[$synthKeyX][0];
+                this.shadow
+                        .querySelector(toe)
+                        .style.setProperty('--translate-x', `${xDiff}px`);
 
-		// Animate the hand and the key using CSS
-		this._toggle([`#bk${relNote}`, hand], c.CLASS_HIT, true);
+                // Animate the toe and the key using CSS
+                this._toggle([`#bk${relNote}`, toe], c.CLASS_HIT, true);
 
 		this._toggle('#synthb', c.CLASS_FADED, false);
 	}
@@ -595,26 +595,26 @@ class Rbbrto extends HTMLElement {
 		this._show(layer0);
 		this._toggle(layer0, c.CLASS_HIT, true);
 
-		const hideLeftHand = !(
-			note0.hands.includes(c.SIDE_LEFT) && note1.hands.includes(c.SIDE_LEFT)
-		);
-		this._toggle(DRUM_HAND_LEFT, c.CLASS_HIDDEN, hideLeftHand);
+                const hideLeftToe = !(
+                        note0.toes.includes(c.SIDE_LEFT) && note1.toes.includes(c.SIDE_LEFT)
+                );
+                this._toggle(DRUM_TOE_LEFT, c.CLASS_HIDDEN, hideLeftToe);
 
-		const hideRightHand = !(
-			note0.hands.includes(c.SIDE_RIGHT) && note1.hands.includes(c.SIDE_RIGHT)
-		);
-		this._toggle(DRUM_HAND_RIGHT, c.CLASS_HIDDEN, hideRightHand);
+                const hideRightToe = !(
+                        note0.toes.includes(c.SIDE_RIGHT) && note1.toes.includes(c.SIDE_RIGHT)
+                );
+                this._toggle(DRUM_TOE_RIGHT, c.CLASS_HIDDEN, hideRightToe);
 
 		const hideCowbell = note0.cowbell === false || note1.cowbell === false;
 		this._toggle(COWBELL, c.CLASS_HIDDEN, hideCowbell);
 
-		// When two notes are played, only show both
-		// if the gorilla can pull it off
-		if (
-			note0.hands === 'lr' ||
-			note1.hands === 'lr' ||
-			(note0.cowbell === false || note1.cowbell === false)
-		) {
+                // When two notes are played, only show both
+                // if the big foot can pull it off
+                if (
+                        note0.toes === 'lr' ||
+                        note1.toes === 'lr' ||
+                        (note0.cowbell === false || note1.cowbell === false)
+                ) {
 			const layer1 = note1.layer;
 			this._show(layer1);
 			this._toggle(layer1, c.CLASS_HIT, true);
@@ -710,7 +710,7 @@ class Rbbrto extends HTMLElement {
 		this._show('#druma');
 		this._hide('#drumb');
 
-		this._hide([DRUM_HAND_LEFT, DRUM_HAND_RIGHT, FACE(0), FACE(1)]);
+                this._hide([DRUM_TOE_LEFT, DRUM_TOE_RIGHT, FACE(0), FACE(1)]);
 
 		this._toggle(COWBELL, c.CLASS_FADED, !this.playback);
 
@@ -729,10 +729,10 @@ class Rbbrto extends HTMLElement {
 	}
 
 	/**
-	 * Set the drum gorilla to stay idle
+        * Set the drum big foot to stay idle
 	 */
 	_idleDrums() {
-		this._show([DRUM_HAND_LEFT, DRUM_HAND_RIGHT, FACE(0), COWBELL]);
+                this._show([DRUM_TOE_LEFT, DRUM_TOE_RIGHT, FACE(0), COWBELL]);
 		this._toggle(COWBELL, c.CLASS_FADED, !this[$drumPlayback]);
 	}
 
@@ -745,12 +745,12 @@ class Rbbrto extends HTMLElement {
 				'#hald',
 				'#hard',
 				'#haru',
-				'#halu',
-				KEY_GUIDE,
-				SYNTH_PLAY_HAND_LEFT,
-				SYNTH_PLAY_HAND_RIGHT
-			].concat(SYNTH_LEFT)
-		);
+                                '#halu',
+                                KEY_GUIDE,
+                                SYNTH_PLAY_TOE_LEFT,
+                                SYNTH_PLAY_TOE_RIGHT
+                        ].concat(SYNTH_LEFT)
+                );
 		this.shadow.querySelectorAll(SYNTH_BITS_LEFT).forEach(bit => {
 			bit.classList.add(c.CLASS_HIDDEN);
 		});
@@ -761,7 +761,7 @@ class Rbbrto extends HTMLElement {
 
 		this._show('#synthb');
 		this._toggle('#synthb', c.CLASS_FADED, true);
-		this._show([SYNTH_IDLE_HAND_LEFT, SYNTH_IDLE_HAND_RIGHT]);
+                this._show([SYNTH_IDLE_TOE_LEFT, SYNTH_IDLE_TOE_RIGHT]);
 
 		for (let k = 0; k < 12; k++) {
 			this._toggle(`#bk${k}`, c.CLASS_HIT, false);
@@ -772,8 +772,8 @@ class Rbbrto extends HTMLElement {
 	 * Set the synth dude to idle
 	 */
 	_idleSynths() {
-		this._hide([SYNTH_PLAY_HAND_LEFT, SYNTH_PLAY_HAND_RIGHT]);
-		this._show([SYNTH_IDLE_HAND_LEFT, SYNTH_IDLE_HAND_RIGHT]);
+                this._hide([SYNTH_PLAY_TOE_LEFT, SYNTH_PLAY_TOE_RIGHT]);
+                this._show([SYNTH_IDLE_TOE_LEFT, SYNTH_IDLE_TOE_RIGHT]);
 		this._toggle('#synthb', c.CLASS_FADED, !this[$synthPlayback]);
 	}
 

--- a/src/synth.js
+++ b/src/synth.js
@@ -1,12 +1,15 @@
+/**
+ * DOM selectors for the big foot's left-foot keyboard controller
+ */
 export const SYNTH_LEFT = [
-	'#synth > polygon:nth-child(1)',
-	'#synth > polyline:nth-child(28)',
-	'#synth > line:nth-child(77)'
+        '#synth > polygon:nth-child(1)',
+        '#synth > polyline:nth-child(28)',
+        '#synth > line:nth-child(77)'
 ];
 export const SYNTH_BITS_LEFT = '#synth > :nth-child(n+29):nth-child(-n+47)';
 
 export const KEY_GUIDE = '#bkguide';
-export const SYNTH_IDLE_HAND_LEFT = '#hblu';
-export const SYNTH_IDLE_HAND_RIGHT = '#hbru';
-export const SYNTH_PLAY_HAND_LEFT = '#hbld';
-export const SYNTH_PLAY_HAND_RIGHT = '#hbrd';
+export const SYNTH_IDLE_TOE_LEFT = '#hblu';
+export const SYNTH_IDLE_TOE_RIGHT = '#hbru';
+export const SYNTH_PLAY_TOE_LEFT = '#hbld';
+export const SYNTH_PLAY_TOE_RIGHT = '#hbrd';


### PR DESCRIPTION
## Summary
- Rename drum character to a right-footed big foot and express mappings with `toes`
- Swap synth professor controls for a left-footed big foot and update animations to toes
- Switch synth animation naming from hand-hit to toe-hit

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a383377f4832f9dbd0b1e5302fef1